### PR TITLE
Fix legend label

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -80,6 +80,7 @@ function App() {
         borderColor: "rgba(75, 75, 75, 1)",
         data: ratiosExtrp, 
         borderDash: [20, 20],
+        borderWidth: 0,
         pointBorderColor: "rgba(0,0,0,0)",
       },
     ],


### PR DESCRIPTION
Makes the line smaller, but fixes the legend label.

With the line itself being dashed, the label follows suit. Easiest fix is to just remove the border of the line + label altogether.